### PR TITLE
Dancer2 no longer support the :syntax import tag

### DIFF
--- a/t/default.t
+++ b/t/default.t
@@ -6,7 +6,7 @@ use File::Temp 0.19; # newdir
 use LWP::UserAgent;
 use Test::TCP;
 
-use Dancer2 ':syntax';
+use Dancer2;
 use Dancer2::Plugin::Auth::Tiny;
 
 test_tcp(

--- a/t/extend.t
+++ b/t/extend.t
@@ -6,7 +6,7 @@ use File::Temp 0.19; # newdir
 use LWP::UserAgent;
 use Test::TCP;
 
-use Dancer2 ':syntax';
+use Dancer2;
 use Dancer2::Plugin::Auth::Tiny;
 
 Dancer2::Plugin::Auth::Tiny->extend(

--- a/t/params.t
+++ b/t/params.t
@@ -30,7 +30,7 @@ test_tcp(
   server => sub {
     my $port = shift;
 
-    use Dancer2 ':syntax';
+    use Dancer2;
     use Dancer2::Plugin::Auth::Tiny;
 
     set confdir     => '.';

--- a/t/settings.t
+++ b/t/settings.t
@@ -6,7 +6,7 @@ use File::Temp 0.19; # newdir
 use LWP::UserAgent;
 use Test::TCP;
 
-use Dancer2 ':syntax';
+use Dancer2;
 use Dancer2::Plugin::Auth::Tiny;
 
 test_tcp(


### PR DESCRIPTION
Small PR to fix the test suite to work with recent Dancer2's that dropped the :syntax import tag.
