### PR TITLE
docs: replace comma with semicolon

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Tiny.pm
+++ b/lib/Dancer2/Plugin/Auth/Tiny.pm
@@ -84,7 +84,7 @@ register_plugin for_versions => [2];
 
   post '/login' => sub {
     if ( _is_valid( params->{user}, params->{password} ) ) {
-      session user => params->{user},
+      session user => params->{user};
       return redirect params->{return_url} || '/';
     }
     else {


### PR DESCRIPTION
Sorry to bother you with a one-character change, but this character cost me an hour while trying to throw up a "bare minimum" authentication example.  I should know better.