### PR TITLE
Updated docs to reflect recent changes in Dancer2 auth options.

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Tiny.pm
+++ b/lib/Dancer2/Plugin/Auth/Tiny.pm
@@ -193,12 +193,13 @@ For more complex L<Dancer2> authentication, see:
 =for :list
 * L<Dancer2::Plugin::Auth::Extensible>
 * L<Dancer2::Plugin::Auth::RBAC> -- possibly not yet (or going to be) ported to Dancer2
+* L<Dancer2::Plugin::Auth::YARBAC>
 
 For password authentication algorithms for your own '/login' handler, see:
 
 =for :list
 * L<Auth::Passphrase>
-* L<Dancer::Plugin::Passphrase> -- possibly not yet ported to Dancer2
+* L<Dancer2::Plugin::Passphrase>
 
 =head1 ACKNOWLEDGMENTS
 


### PR DESCRIPTION
Dancer::Plugin::Passphrase has been successfully ported to Dancer2, and
have changed the pod to reflect that this has happened, and is no longer
a maybe. Also, while Dancer::Plugin::Auth::RBAC hasn't been ported to
Dancer2, Dancer2::Plugin::Auth::YARBAC seems like a capable option, so
have listed it in the pod as an option for developers.