### PR TITLE
stop using deprecated plugin_args

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Tiny.pm
+++ b/lib/Dancer2/Plugin/Auth/Tiny.pm
@@ -14,7 +14,7 @@ my $conf;
 my %dispatch = ( login => \&_build_login, );
 
 register 'needs' => sub {
-    my ( $dsl, $condition, @args ) = plugin_args(@_);
+    my ( $dsl, $condition, @args ) = @_;
 
     my $builder = $dispatch{$condition};
 


### PR DESCRIPTION
plugin2 compatibility to remove deprecation warnings.